### PR TITLE
Fix -target path injected at end of operations instead of beginning

### DIFF
--- a/generator/operation.go
+++ b/generator/operation.go
@@ -152,7 +152,7 @@ func (o *operationGenerator) generateHandler() error {
 	}
 	log.Println("rendered handler template:", o.pkg+"."+o.cname)
 
-	fp := filepath.Join(o.ServerPackage, o.Target)
+	fp := filepath.Join(o.Target, o.ServerPackage)
 	if len(o.Operation.Tags) > 0 {
 		fp = filepath.Join(fp, o.pkg)
 	}
@@ -167,7 +167,7 @@ func (o *operationGenerator) generateParameterModel() error {
 	}
 	log.Println("rendered parameters template:", o.pkg+"."+o.cname+"Parameters")
 
-	fp := filepath.Join(o.ServerPackage, o.Target)
+	fp := filepath.Join(o.Target, o.ServerPackage)
 	if len(o.Operation.Tags) > 0 {
 		fp = filepath.Join(fp, o.pkg)
 	}


### PR DESCRIPTION
I found that when I used -target, I was still getting restapi stuff ditched into my gopath.

I believe the fix below covers that issue.
